### PR TITLE
Fix syntax error in json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "websocket": "~1.0.21",
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
-    "multer": "^1.2.0"
+    "multer": "^1.2.0",
     "websocket": "~1.0.21"
   }
 }


### PR DESCRIPTION
There was a simple syntax error in the package.json file that prevented the "npm install" command from working. This fixes it.